### PR TITLE
Allow publishing to npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "Taggle.js",
+  "name": "taggle",
   "version": "1.4.0",
   "description": "Taggle is a dependency-less tagging library",
   "author": "Sean Coker <sean@seancoker.com>",
+  "main": "src/taggle.js",
   "url": "http://sean.is/poppin/tags",
   "repository": "git@github.com:okcoker/taggle.js.git",
   "devDependencies": {
@@ -15,5 +16,7 @@
     "grunt-mocha": "^0.4.11",
     "load-grunt-config": "~0.7.1",
     "load-grunt-tasks": "~0.4.0"
+  },
+  "dependencies": {
   }
 }

--- a/src/taggle.js
+++ b/src/taggle.js
@@ -631,4 +631,18 @@
 
     window.Taggle = Taggle;
 
+    /* global define, module */
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD
+        define([], function () {
+            return Taggle;
+        });
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        module.exports = Taggle;
+    } else {
+        // Vanilla browser global
+        window.Taggle = Taggle;
+    }
+
 }(window, document));


### PR DESCRIPTION
I'll let you do the honors of actually _publishing_, @okcoker, but this PR makes it easier to use taggle.js from CommonJS-based applications. In my particular case, I've integrated my fork with this commit with a Browserified React application.