### PR TITLE
call onTagRemove after the tag has been removed

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -506,10 +506,10 @@
             span = li.querySelector('.taggle_text');
             text = span.innerText || span.textContent;
 
-            settings.onTagRemove(e, text);
-
             li.parentNode.removeChild(li);
             _removeFromTheTags(li, tag);
+
+            settings.onTagRemove(e, text);
 
             _focusInput();
         }


### PR DESCRIPTION
I noticed that `taggle.getTagValues()` returned the previous value of the input when it was called in `onTagRemove`. Did you have a reason for this behavior or was it simply a bug?

Btw, its nice to see a decent taginput library not depending on jQuery.