### PR TITLE
Add support for removing all tags at once

### DIFF
--- a/assets/js/taggle.js
+++ b/assets/js/taggle.js
@@ -572,6 +572,14 @@
             return self;
         };
 
+        self.removeAll = function() {
+            for (var i = tag.values.length - 1; i >= 0; i--) {
+                _remove(tag.elements[i]);
+            }
+
+            return self;
+        };
+
         // Bang bang bang skeet skeet
         _init();
     };

--- a/src/taggle.js
+++ b/src/taggle.js
@@ -572,6 +572,14 @@
             return self;
         };
 
+        self.removeAll = function() {
+            for (var i = tag.values.length - 1; i >= 0; i--) {
+                _remove(tag.elements[i]);
+            }
+
+            return self;
+        };
+
         // Bang bang bang skeet skeet
         _init();
     };

--- a/taggle.html
+++ b/taggle.html
@@ -289,6 +289,10 @@ var taggle = new Taggle('example7', {
         <p>Pass a string to remove the most recent occurance of the tag. Pass true to the second argument to remove all occurances of the tag.</p>
     </div>
     <div class="option">
+        <p>removeAll()</p>
+        <p>Remove all tags at once, including duplicates.</p>
+    </div>
+    <div class="option">
         <p>
             getTags() <code>Returns {Object}</code>
         </p>

--- a/test/taggle-test.js
+++ b/test/taggle-test.js
@@ -256,6 +256,21 @@
                     expect(this.instance.getTagValues()[3]).to.equal('four');
                 });
             });
+
+            describe('#removeAll', function() {
+                beforeEach(function() {
+                    this.instance = new Taggle(this.container, {
+                        tags: ['zero', 'one', 'two', 'three', 'four', 'three']
+                    });
+                });
+
+                it('should remove all existent tags', function() {
+                    expect(this.instance.getTagElements().length).to.equal(6);
+                    this.instance.removeAll();
+                    expect(this.instance.getTagElements().length).to.equal(0);
+                    expect(this.instance.getTagValues().length).to.equal(0);
+                });
+            });
         });
     });
 


### PR DESCRIPTION
This PR adds a new method called `removeAll()` that shall be used to remove all tags.

Related to #16.