### PR TITLE
Define library with UMD

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -639,6 +639,18 @@
         }
     }
 
-    window.Taggle = Taggle;
+    /* global define, module */
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD
+        define([], function () {
+            return Taggle;
+        });
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        module.exports = Taggle;
+    } else {
+        // Vanilla browser global
+        window.Taggle = Taggle;
+    }
 
 }(window, document));


### PR DESCRIPTION
Use UMD pattern to expose module for better support in AMD/CommonJS
settings.

(more or less a rehash of #10)