### PR TITLE
Fixed error due to incorrectly linked css file

### DIFF
--- a/taggle.html
+++ b/taggle.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8">
 <link type="text/css" href="assets/css/twilight.css" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="assets/css/projects.min.css">
-<link rel="stylesheet" type="text/css" href="assets/css/taggle.min.css">
+<link rel="stylesheet" type="text/css" href="assets/css/taggle.css">
 <!--[if lte IE 8]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->


### PR DESCRIPTION
File 'taggle.min.css' does not exist, only 'taggle.css'.