### PR TITLE
Fix saveOnBlur, Add focusInputOnContainerClick option

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -542,6 +542,14 @@
      * @param  {Event} e
      */
     Taggle.prototype._blurEvent = function(e) {
+        if (this.container.classList.contains(this.settings.containerFocusClass)) {
+            this.container.classList.remove(this.settings.containerFocusClass);
+        }
+
+        if (!this.tag.values.length && this.placeholder) {
+            this.placeholder.style.opacity = 1;
+        }
+
         if (this.settings.saveOnBlur) {
             e = e || window.event;
 
@@ -555,19 +563,10 @@
             if (this.tag.values.length) {
                 this._checkLastTag(e);
             }
-
         }
         else {
             this.input.value = '';
             this._setInputWidth();
-
-            if (this.container.classList.contains(this.settings.containerFocusClass)) {
-                this.container.classList.remove(this.settings.containerFocusClass);
-            }
-
-            if (!this.tag.values.length && this.placeholder) {
-                this.placeholder.style.opacity = 1;
-            }
         }
     };
 

--- a/src/taggle.js
+++ b/src/taggle.js
@@ -51,6 +51,12 @@
         containerFocusClass: 'active',
 
         /**
+         * Should the input be focused when the container is clicked?
+         * @type {Bool}
+         */
+        focusInputOnContainerClick: true,
+
+        /**
          * Name added to the hidden inputs within each tag
          * @type {String}
          */
@@ -302,9 +308,11 @@
     Taggle.prototype._attachEvents = function() {
         var self = this;
 
-        _on(this.container, 'click', function() {
-            self.input.focus();
-        });
+        if (this.settings.focusInputOnContainerClick) {
+            _on(this.container, 'click', function() {
+                self.input.focus();
+            });
+        }
 
         _on(this.input, 'focus', this._focusInput.bind(this));
         _on(this.input, 'blur', this._blurEvent.bind(this));

--- a/taggle.html
+++ b/taggle.html
@@ -268,6 +268,14 @@ var taggle = new Taggle('example7b', {
             </div>
             <div class="option">
                 <p>
+                    focusInputOnContainerClick: <code>[Boolean=true]</code>
+                </p>
+                <p>
+                    If <code>true</code> then <code>input</code> will be focused when <code>container</code> receives a click event.
+                </p>
+            </div>
+            <div class="option">
+                <p>
                     hiddenInputName: <code>[String='taggles[]']</code>
                 </p>
                 <p>
@@ -305,10 +313,14 @@ var taggle = new Taggle('example7b', {
                 <p>
                     These will be the tags that should be preloaded in the taggle field when the plugin loads.
                 </p>
-                <div class="option">
-                    <p>allowedTags: <code>[Array=[]]</code></p>
-                    <p>Tags that the user will be restricted to.</p>
-                </div>
+            </div>
+            <div class="option">
+                <p>
+                    allowedTags: <code>[Array=[]]</code>
+                </p>
+                <p>
+                    Tags that the user will be restricted to.
+                </p>
             </div>
             <div class="option">
                 <p>

--- a/test/taggle-test.js
+++ b/test/taggle-test.js
@@ -1,9 +1,6 @@
 var expect = chai.expect;
 
-// Patch since PhantomJS does not implement click() on HTMLElement. In some
-// cases we need to execute the native click on an element. However, jQuery's
-// $.fn.click() does not dispatch to the native function on <a> elements, so we
-// can't use it in our implementations: $el[0].click() to correctly dispatch.
+// Patch since PhantomJS does not implement click() on HTMLElement.
 if (!HTMLElement.prototype.click) {
     HTMLElement.prototype.click = function() {
         var ev = document.createEvent('MouseEvent');
@@ -607,6 +604,18 @@ describe('Taggle', function() {
 
                 expect(this.instance.getTagValues().length).to.equal(1);
                 expect(this.instance.getTagValues()[0]).to.equal(tag);
+            });
+
+            it('should not prevent the container from losing focus class when input is blurred', function() {
+                var input = this.instance.getInput();
+
+                input.focus();
+
+                expect(this.instance.getContainer().classList.contains(this.instance.settings.containerFocusClass)).to.be.true
+
+                input.blur();
+
+                expect(this.instance.getContainer().classList.contains(this.instance.settings.containerFocusClass)).to.be.false
             });
         });
 


### PR DESCRIPTION
This contains a fix for #45 and #46 including passing tests.

Additionally I added an option to disable the behavior where the input is focused when the container receives a click.