### PR TITLE
Use event.key instead of event.keyCode for support of unicode charact…

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -17,10 +17,10 @@
     var retTrue = function() {
         return true;
     };
-    var BACKSPACE = 8;
-    var COMMA = 188;
-    var TAB = 9;
-    var ENTER = 13;
+    var BACKSPACE = 'Backspace';
+    var COMMA = ',';
+    var TAB = 'Tab';
+    var ENTER = 'Enter';
 
     var DEFAULTS = {
         /**
@@ -475,7 +475,7 @@
         var heldDown = this.input.classList.contains('taggle_back');
 
         // prevent holding backspace from deleting all tags
-        if (this.input.value === '' && e.keyCode === BACKSPACE && !heldDown) {
+        if (this.input.value === '' && e.key === BACKSPACE && !heldDown) {
             if (lastTaggle.classList.contains(hotClass)) {
                 this.input.classList.add('taggle_back');
                 this._remove(lastTaggle, e);
@@ -599,7 +599,7 @@
     Taggle.prototype._keydownEvents = function(e) {
         e = e || window.event;
 
-        var key = e.keyCode;
+        var key = e.key;
         this.pasting = false;
 
         this._listenForEndOfContainer();


### PR DESCRIPTION
Change event.key to event.keyCode to allow unicode characters which otherwise accidentally can trigger 'action' keys (for example, the hebrew ת translates as the comma key, which causes a tag to appear). Also, change BACKSPACE, ENTER, TAB and COMMA contants accordingly.
