### PR TITLE
Make taggle compatible with xhtml

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -794,7 +794,7 @@
 
         text = this._formatTag(text);
 
-        close.innerHTML = '&times;';
+        _setText(close, '×');
         close.className = 'close';
         // IE8 does not allow you to modify the `type` property directly.
         close.setAttribute('type', 'button');
@@ -822,7 +822,7 @@
             li = formatted;
         }
 
-        if (!(li instanceof HTMLElement) || li.tagName !== 'LI') {
+        if (!(li instanceof HTMLElement) || !(li.localName === 'li' || li.tagName === 'LI')) {
             throw new Error('tagFormatter must return an li element');
         }
 


### PR DESCRIPTION
This PR allows Taggle to be used with a page served as `application/xhtml+xml` by:

1. Replacing the `&times;` HTML entity with the × character directly

2. Changing the tagFormatter return validation logic to check `localName`, which works in both `application/xhtml+xml` and `text/html`, and for compatibility with IE 8, `tagName` as fallback.