### PR TITLE
Prevent default event when input is empty and key pressed is `COMMA`

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -727,6 +727,11 @@
             this.pasting = true;
         }
 
+        if (this._isConfirmKey(key) && key === COMMA && this.input.value === '') {
+            e.preventDefault();
+            return;
+        }
+
         if (this._isConfirmKey(key) && this.input.value !== '') {
             this._confirmValidTagEvent(e);
             return;


### PR DESCRIPTION
Typing a `COMMA` in a taggle input is expected to call the submit method and attempt to create a new tag, unless the input is empty. In this case it is possible for a user to inadvertently create a tag with leading spaces.

**Example**

User types something like this:
```
,   my tag
```
which results in a new tag being added with leading spaces:
```
   my tag
```

This PR fixes this edge case by preventing a `COMMA` from being typed in when the input is empty.
