### PR TITLE
strip leading delimiter character when trimming tags

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -545,16 +545,18 @@
     Taggle.prototype._add = function(e, text, index) {
         var self = this;
         var values = text || '';
+        var delimiter = this.settings.delimiter || this.settings.delimeter;
 
         if (typeof text !== 'string') {
             values = this.input.value;
 
             if (this.settings.trimTags) {
-                values = _trim(this.input.value);
+                if (values[0] === delimiter) {
+                    values = values.replace(delimiter, '');
+                }
+                values = _trim(values);
             }
         }
-
-        var delimiter = this.settings.delimiter || this.settings.delimeter;
 
         values.split(delimiter).map(function(val) {
             return self._formatTag(val);

--- a/test/taggle-test.js
+++ b/test/taggle-test.js
@@ -204,13 +204,19 @@ describe('Taggle', function() {
         it('should trim tags by default', function() {
             var taggle = new Taggle(this.container);
             var input = taggle.getInput();
+            var tag = '   tag';
+            var tag2 = ',   spaaace  ';
 
-            input.value = '   tag';
+            input.value = tag;
 
             simulateKeyboardEvent('keydown', input, 188);
 
-            expect(taggle.getTags().values).to.eql(['tag']);
-            expect(taggle.getTags().values.length).to.equal(1);
+            input.value = tag2;
+
+            simulateKeyboardEvent('keydown', input, 188);
+
+            expect(taggle.getTags().values).to.eql(['tag', 'spaaace']);
+            expect(taggle.getTags().values.length).to.equal(2);
         });
 
         it('should not trim tags when `trimTags` is `false`', function() {

--- a/test/taggle-test.js
+++ b/test/taggle-test.js
@@ -219,6 +219,24 @@ describe('Taggle', function() {
             expect(taggle.getTags().values.length).to.equal(2);
         });
 
+        it('should trim tags by default when delimiter is customized', function() {
+            var taggle = new Taggle(this.container, { delimiter: '|' });
+            var input = taggle.getInput();
+            var tag = '   tag';
+            var tag2 = '|   spaaace  ';
+
+            input.value = tag;
+
+            simulateKeyboardEvent('keydown', input, 188);
+
+            input.value = tag2;
+
+            simulateKeyboardEvent('keydown', input, 188);
+
+            expect(taggle.getTags().values).to.eql(['tag', 'spaaace']);
+            expect(taggle.getTags().values.length).to.equal(2);
+        });
+
         it('should not trim tags when `trimTags` is `false`', function() {
             var taggle = new Taggle(this.container, {
                 trimTags: false


### PR DESCRIPTION
Handles the case where a user may begin typing a tag with a delimiter character followed by any number of spaces. Without checking for and replacing a leading delimiter character the tag will not be trimmed as expected.

Alternate approach to the issue raised in #140 but doesn't rely on preventing default.